### PR TITLE
feat: split failed/passed suites in test report

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -47524,32 +47524,51 @@ function getSuitesReport(tr, runIndex, options) {
   const time = formatTime(tr.time);
   const headingLine2 = tr.tests > 0 ? `**${tr.tests}** tests were completed in **${time}** with **${tr.passed}** passed, **${tr.failed}** failed and **${tr.skipped}** skipped.` : "No tests found";
   sections.push(headingLine2);
-  const suites = options.listSuites === "failed" ? tr.failedSuites : tr.suites;
-  if (suites.length > 0) {
-    const suitesTable = table(
-      ["Test suite", "Passed", "Failed", "Skipped", "Time"],
-      [":---" /* Left */, "---:" /* Right */, "---:" /* Right */, "---:" /* Right */, "---:" /* Right */],
-      ...suites.map((s, suiteIndex) => {
-        const tsTime = formatTime(s.time);
-        const tsName = s.name.startsWith(name) ? s.name.slice(name.length + 1) : s.name;
-        const skipLink = options.listTests === "none" || options.listTests === "failed" && s.result !== "failed";
-        s.link = options.baseUrl + makeSuiteSlug(runIndex, suiteIndex).link;
-        const tsNameLink = skipLink ? tsName : link(tsName, s.link);
-        const passed = s.passed > 0 ? `${s.passed}${Icon.success}` : "";
-        const failed = s.failed > 0 ? `${s.failed}${Icon.fail}` : "";
-        const skipped = s.skipped > 0 ? `${s.skipped}${Icon.skip}` : "";
-        return [tsNameLink, passed, failed, skipped, tsTime];
-      })
-    );
-    sections.push(suitesTable);
+  const failedSuites = tr.suites.filter((s) => s.result === "failed");
+  const passedSuites = tr.suites.filter((s) => s.result !== "failed");
+  const hasFailedSuites = failedSuites.length > 0;
+  const suitesToShow = options.listSuites === "failed" ? failedSuites : hasFailedSuites ? failedSuites : tr.suites;
+  if (suitesToShow.length > 0) {
+    sections.push(renderSuitesTable(suitesToShow, name, runIndex, options));
   }
   if (options.listTests !== "none") {
-    const tests = suites.map((ts, suiteIndex) => getTestsReport(ts, runIndex, suiteIndex, options)).flat();
+    const tests = suitesToShow.map((ts) => {
+      const originalIndex = tr.suites.indexOf(ts);
+      return getTestsReport(ts, runIndex, originalIndex, options);
+    }).flat();
     if (tests.length > 1) {
       sections.push(...tests);
     }
   }
+  if (hasFailedSuites && passedSuites.length > 0 && options.listSuites === "all") {
+    const passedCount = passedSuites.reduce((sum, s) => sum + s.passed, 0);
+    sections.push("");
+    sections.push("<details>");
+    sections.push(`<summary>${Icon.success} ${passedCount} passed tests in ${passedSuites.length} suites</summary>`);
+    sections.push("");
+    sections.push(renderSuitesTable(passedSuites, name, runIndex, options));
+    sections.push("");
+    sections.push("</details>");
+  }
   return sections;
+}
+function renderSuitesTable(suites, runName, runIndex, options) {
+  return table(
+    ["Test suite", "Passed", "Failed", "Skipped", "Time"],
+    [":---" /* Left */, "---:" /* Right */, "---:" /* Right */, "---:" /* Right */, "---:" /* Right */],
+    ...suites.map((s) => {
+      const suiteIndex = suites.indexOf(s);
+      const tsTime = formatTime(s.time);
+      const tsName = s.name.startsWith(runName) ? s.name.slice(runName.length + 1) : s.name;
+      const skipLink = options.listTests === "none" || options.listTests === "failed" && s.result !== "failed";
+      s.link = options.baseUrl + makeSuiteSlug(runIndex, suiteIndex).link;
+      const tsNameLink = skipLink ? tsName : link(tsName, s.link);
+      const passed = s.passed > 0 ? `${s.passed}${Icon.success}` : "";
+      const failed = s.failed > 0 ? `${s.failed}${Icon.fail}` : "";
+      const skipped = s.skipped > 0 ? `${s.skipped}${Icon.skip}` : "";
+      return [tsNameLink, passed, failed, skipped, tsTime];
+    })
+  );
 }
 function getTestsReport(ts, runIndex, suiteIndex, options) {
   if (options.listTests === "failed" && ts.result !== "failed") {

--- a/src/report/get-report.ts
+++ b/src/report/get-report.ts
@@ -227,35 +227,69 @@ function getSuitesReport(tr: TestRunResult, runIndex: number, options: ReportOpt
       : 'No tests found'
   sections.push(headingLine2)
 
-  const suites = options.listSuites === 'failed' ? tr.failedSuites : tr.suites
-  if (suites.length > 0) {
-    const suitesTable = table(
-      ['Test suite', 'Passed', 'Failed', 'Skipped', 'Time'],
-      [Align.Left, Align.Right, Align.Right, Align.Right, Align.Right],
-      ...suites.map((s, suiteIndex) => {
-        const tsTime = formatTime(s.time)
-        const tsName = s.name.startsWith(name) ? s.name.slice(name.length + 1) : s.name
-        const skipLink = options.listTests === 'none' || (options.listTests === 'failed' && s.result !== 'failed')
-        s.link = options.baseUrl + makeSuiteSlug(runIndex, suiteIndex).link
-        const tsNameLink = skipLink ? tsName : link(tsName, s.link)
-        const passed = s.passed > 0 ? `${s.passed}${Icon.success}` : ''
-        const failed = s.failed > 0 ? `${s.failed}${Icon.fail}` : ''
-        const skipped = s.skipped > 0 ? `${s.skipped}${Icon.skip}` : ''
-        return [tsNameLink, passed, failed, skipped, tsTime]
-      })
-    )
-    sections.push(suitesTable)
+  // Split suites into failed and passed
+  const failedSuites = tr.suites.filter(s => s.result === 'failed')
+  const passedSuites = tr.suites.filter(s => s.result !== 'failed')
+  const hasFailedSuites = failedSuites.length > 0
+
+  // Determine which suites to show based on options and failures
+  const suitesToShow = options.listSuites === 'failed' ? failedSuites : hasFailedSuites ? failedSuites : tr.suites
+
+  if (suitesToShow.length > 0) {
+    sections.push(renderSuitesTable(suitesToShow, name, runIndex, options))
   }
 
+  // Show detailed test results for failed suites
   if (options.listTests !== 'none') {
-    const tests = suites.map((ts, suiteIndex) => getTestsReport(ts, runIndex, suiteIndex, options)).flat()
+    const tests = suitesToShow
+      .map(ts => {
+        const originalIndex = tr.suites.indexOf(ts)
+        return getTestsReport(ts, runIndex, originalIndex, options)
+      })
+      .flat()
 
     if (tests.length > 1) {
       sections.push(...tests)
     }
   }
 
+  // Show passed suites in collapsed section (only if we have failures and listSuites is 'all')
+  if (hasFailedSuites && passedSuites.length > 0 && options.listSuites === 'all') {
+    const passedCount = passedSuites.reduce((sum, s) => sum + s.passed, 0)
+    sections.push('')
+    sections.push('<details>')
+    sections.push(`<summary>${Icon.success} ${passedCount} passed tests in ${passedSuites.length} suites</summary>`)
+    sections.push('')
+    sections.push(renderSuitesTable(passedSuites, name, runIndex, options))
+    sections.push('')
+    sections.push('</details>')
+  }
+
   return sections
+}
+
+function renderSuitesTable(
+  suites: TestSuiteResult[],
+  runName: string,
+  runIndex: number,
+  options: ReportOptions
+): string {
+  return table(
+    ['Test suite', 'Passed', 'Failed', 'Skipped', 'Time'],
+    [Align.Left, Align.Right, Align.Right, Align.Right, Align.Right],
+    ...suites.map(s => {
+      const suiteIndex = suites.indexOf(s)
+      const tsTime = formatTime(s.time)
+      const tsName = s.name.startsWith(runName) ? s.name.slice(runName.length + 1) : s.name
+      const skipLink = options.listTests === 'none' || (options.listTests === 'failed' && s.result !== 'failed')
+      s.link = options.baseUrl + makeSuiteSlug(runIndex, suiteIndex).link
+      const tsNameLink = skipLink ? tsName : link(tsName, s.link)
+      const passed = s.passed > 0 ? `${s.passed}${Icon.success}` : ''
+      const failed = s.failed > 0 ? `${s.failed}${Icon.fail}` : ''
+      const skipped = s.skipped > 0 ? `${s.skipped}${Icon.skip}` : ''
+      return [tsNameLink, passed, failed, skipped, tsTime]
+    })
+  )
 }
 
 function getTestsReport(ts: TestSuiteResult, runIndex: number, suiteIndex: number, options: ReportOptions): string[] {


### PR DESCRIPTION
## Summary
When a test run has failures, the report now:
- Shows **only failed suites** in the main visible table
- Moves **passed suites** to a collapsed `<details>` section

This makes it much easier to focus on failures without scrolling through hundreds of passed suites (e.g., EVA.TestSuite.Core with 4800+ tests).

### Before
All suites listed together in one long table

### After
```
## ❌ EVA.TestSuite.Core
|Test suite|Passed|Failed|Skipped|Time|
|Pricing.GetProductPricesTests|5✅|1❌||83s|

<details>
<summary>✅ 4853 passed tests in 195 suites</summary>

|Test suite|Passed|Failed|Skipped|Time|
|Accounts.AccountCrudTests|1✅|||385ms|
...
</details>
```

🤖 Generated with [Claude Code](https://claude.ai/code)