### PR TITLE
fix: reduce memory usage by lazy loading TRX files

### DIFF
--- a/__tests__/dotnet-trx.test.ts
+++ b/__tests__/dotnet-trx.test.ts
@@ -1,7 +1,8 @@
+import * as fs from 'fs'
 import {DotnetTrxParser} from '../src/parsers/dotnet-trx/dotnet-trx-parser'
 import {ParseOptions} from '../src/test-parser'
 import {LocalFileProvider} from '../src/input-providers/local-file-provider'
-import {TestRunResult, TestRunResultWithUrl} from '../src/test-results'
+import {TestRunResult} from '../src/test-results'
 import {groupByDirectory} from '../src/utils/merge-utils'
 
 it('matches report snapshot', async () => {
@@ -15,11 +16,10 @@ it('matches report snapshot', async () => {
   const input = await inputProvider.load()
 
   let results: TestRunResult[] = []
-  for (const [reportName, files] of Object.entries(input.reports)) {
-    for (const {file, content} of files) {
-      const tr = await parser.parse(file, content)
-      results.push(tr)
-    }
+  for (const file of input.files) {
+    const content = await fs.promises.readFile(file, {encoding: 'utf8'})
+    const tr = await parser.parse(file, content)
+    results.push(tr)
   }
 
   results = groupByDirectory(results)

--- a/dist/index.js
+++ b/dist/index.js
@@ -22762,8 +22762,8 @@ var require_utils4 = __commonJS({
     exports2.array = array;
     var errno = require_errno();
     exports2.errno = errno;
-    var fs5 = require_fs();
-    exports2.fs = fs5;
+    var fs4 = require_fs();
+    exports2.fs = fs4;
     var path5 = require_path();
     exports2.path = path5;
     var pattern = require_pattern();
@@ -22947,12 +22947,12 @@ var require_fs2 = __commonJS({
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.createFileSystemAdapter = exports2.FILE_SYSTEM_ADAPTER = void 0;
-    var fs5 = require("fs");
+    var fs4 = require("fs");
     exports2.FILE_SYSTEM_ADAPTER = {
-      lstat: fs5.lstat,
-      stat: fs5.stat,
-      lstatSync: fs5.lstatSync,
-      statSync: fs5.statSync
+      lstat: fs4.lstat,
+      stat: fs4.stat,
+      lstatSync: fs4.lstatSync,
+      statSync: fs4.statSync
     };
     function createFileSystemAdapter(fsMethods) {
       if (fsMethods === void 0) {
@@ -22969,12 +22969,12 @@ var require_settings = __commonJS({
   "node_modules/@nodelib/fs.stat/out/settings.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
-    var fs5 = require_fs2();
+    var fs4 = require_fs2();
     var Settings = class {
       constructor(_options = {}) {
         this._options = _options;
         this.followSymbolicLink = this._getValue(this._options.followSymbolicLink, true);
-        this.fs = fs5.createFileSystemAdapter(this._options.fs);
+        this.fs = fs4.createFileSystemAdapter(this._options.fs);
         this.markSymbolicLink = this._getValue(this._options.markSymbolicLink, false);
         this.throwErrorOnBrokenSymbolicLink = this._getValue(this._options.throwErrorOnBrokenSymbolicLink, true);
       }
@@ -23129,8 +23129,8 @@ var require_utils5 = __commonJS({
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.fs = void 0;
-    var fs5 = require_fs3();
-    exports2.fs = fs5;
+    var fs4 = require_fs3();
+    exports2.fs = fs4;
   }
 });
 
@@ -23325,14 +23325,14 @@ var require_fs4 = __commonJS({
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.createFileSystemAdapter = exports2.FILE_SYSTEM_ADAPTER = void 0;
-    var fs5 = require("fs");
+    var fs4 = require("fs");
     exports2.FILE_SYSTEM_ADAPTER = {
-      lstat: fs5.lstat,
-      stat: fs5.stat,
-      lstatSync: fs5.lstatSync,
-      statSync: fs5.statSync,
-      readdir: fs5.readdir,
-      readdirSync: fs5.readdirSync
+      lstat: fs4.lstat,
+      stat: fs4.stat,
+      lstatSync: fs4.lstatSync,
+      statSync: fs4.statSync,
+      readdir: fs4.readdir,
+      readdirSync: fs4.readdirSync
     };
     function createFileSystemAdapter(fsMethods) {
       if (fsMethods === void 0) {
@@ -23351,12 +23351,12 @@ var require_settings2 = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     var path5 = require("path");
     var fsStat = require_out();
-    var fs5 = require_fs4();
+    var fs4 = require_fs4();
     var Settings = class {
       constructor(_options = {}) {
         this._options = _options;
         this.followSymbolicLinks = this._getValue(this._options.followSymbolicLinks, false);
-        this.fs = fs5.createFileSystemAdapter(this._options.fs);
+        this.fs = fs4.createFileSystemAdapter(this._options.fs);
         this.pathSegmentSeparator = this._getValue(this._options.pathSegmentSeparator, path5.sep);
         this.stats = this._getValue(this._options.stats, false);
         this.throwErrorOnBrokenSymbolicLink = this._getValue(this._options.throwErrorOnBrokenSymbolicLink, true);
@@ -24714,16 +24714,16 @@ var require_settings4 = __commonJS({
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.DEFAULT_FILE_SYSTEM_ADAPTER = void 0;
-    var fs5 = require("fs");
+    var fs4 = require("fs");
     var os5 = require("os");
     var CPU_COUNT = Math.max(os5.cpus().length, 1);
     exports2.DEFAULT_FILE_SYSTEM_ADAPTER = {
-      lstat: fs5.lstat,
-      lstatSync: fs5.lstatSync,
-      stat: fs5.stat,
-      statSync: fs5.statSync,
-      readdir: fs5.readdir,
-      readdirSync: fs5.readdirSync
+      lstat: fs4.lstat,
+      lstatSync: fs4.lstatSync,
+      stat: fs4.stat,
+      statSync: fs4.statSync,
+      readdir: fs4.readdir,
+      readdirSync: fs4.readdirSync
     };
     var Settings = class {
       constructor(_options = {}) {
@@ -25410,7 +25410,7 @@ var require_utils6 = __commonJS({
 var require_fattr = __commonJS({
   "node_modules/adm-zip/util/fattr.js"(exports2, module2) {
     var pth = require("path");
-    module2.exports = function(path5, { fs: fs5 }) {
+    module2.exports = function(path5, { fs: fs4 }) {
       var _path = path5 || "", _obj = newAttr(), _stat = null;
       function newAttr() {
         return {
@@ -25422,8 +25422,8 @@ var require_fattr = __commonJS({
           atime: 0
         };
       }
-      if (_path && fs5.existsSync(_path)) {
-        _stat = fs5.statSync(_path);
+      if (_path && fs4.existsSync(_path)) {
+        _stat = fs4.statSync(_path);
         _obj.directory = _stat.isDirectory();
         _obj.mtime = _stat.mtime;
         _obj.atime = _stat.atime;
@@ -37516,7 +37516,7 @@ var require_form_data = __commonJS({
     var http = require("http");
     var https = require("https");
     var parseUrl2 = require("url").parse;
-    var fs5 = require("fs");
+    var fs4 = require("fs");
     var Stream = require("stream").Stream;
     var crypto2 = require("crypto");
     var mime = require_mime_types();
@@ -37583,7 +37583,7 @@ var require_form_data = __commonJS({
         if (value.end != void 0 && value.end != Infinity && value.start != void 0) {
           callback(null, value.end + 1 - (value.start ? value.start : 0));
         } else {
-          fs5.stat(value.path, function(err, stat2) {
+          fs4.stat(value.path, function(err, stat2) {
             if (err) {
               callback(err);
               return;
@@ -42654,8 +42654,8 @@ var require_axios = __commonJS({
     axios.toFormData = toFormData;
     axios.AxiosError = AxiosError$1;
     axios.Cancel = axios.CanceledError;
-    axios.all = function all(promises4) {
-      return Promise.all(promises4);
+    axios.all = function all(promises3) {
+      return Promise.all(promises3);
     };
     axios.spread = spread;
     axios.isAxiosError = isAxiosError;
@@ -47019,7 +47019,6 @@ function getOctokit(token, options, ...additionalPlugins) {
 }
 
 // src/input-providers/local-file-provider.ts
-var fs3 = __toESM(require("fs"));
 var import_fast_glob = __toESM(require_out4());
 var import_adm_zip = __toESM(require_adm_zip());
 var import_path = __toESM(require("path"));
@@ -47029,21 +47028,20 @@ var LocalFileProvider = class {
     this.pattern = pattern;
   }
   async load() {
-    const result = [];
-    const zip = new import_adm_zip.default();
+    const files = [];
     for (const pat of this.pattern) {
       const paths = await (0, import_fast_glob.default)(pat, { dot: true });
-      for (const file of paths) {
-        const dir = import_path.default.dirname(file);
-        zip.addLocalFile(file, dir);
-        const content = await fs3.promises.readFile(file, { encoding: "utf8" });
-        result.push({ file, content });
-      }
+      files.push(...paths);
     }
     return {
-      trxZip: zip,
-      reports: {
-        [this.name]: result
+      files,
+      createZip: () => {
+        const zip = new import_adm_zip.default();
+        for (const file of files) {
+          const dir = import_path.default.dirname(file);
+          zip.addLocalFile(file, dir);
+        }
+        return zip;
       }
     };
   }
@@ -49465,7 +49463,8 @@ var TestReporter = class {
     const input = await inputProvider.load();
     if (this.resultsEndpoint?.length > 0) {
       try {
-        const readStream = input.trxZip.toBuffer();
+        const zip = input.createZip();
+        const readStream = zip.toBuffer();
         const version = import_fs3.default.existsSync("./metadata/version.txt") ? import_fs3.default.readFileSync("./metadata/version.txt").toString() : null;
         const commitID = import_fs3.default.existsSync("./metadata/commit.txt") ? import_fs3.default.readFileSync("./metadata/commit.txt").toString() : null;
         info(
@@ -49484,16 +49483,14 @@ var TestReporter = class {
         warning(`Could not upload TRX ZIP file: ${ex}`);
       }
     }
-    for (const [reportName, files] of Object.entries(input.reports)) {
-      try {
-        startGroup(`Creating test report ${reportName}`);
-        const tr = await this.createReport(parser, reportName, files);
-        if (tr != null) {
-          results.push(tr);
-        }
-      } finally {
-        endGroup();
+    try {
+      startGroup(`Creating test report ${this.name}`);
+      const tr = await this.createReport(parser, this.name, input.files);
+      if (tr != null) {
+        results.push(tr);
       }
+    } finally {
+      endGroup();
     }
     const isFailed = results.some((tr) => tr.results.some((r) => r.isFailed));
     const conclusion = isFailed ? "failure" : "success";
@@ -49532,9 +49529,10 @@ var TestReporter = class {
     info(`Processing test results for check run ${name}`);
     let results = [];
     const result = new TestRunResultWithUrl(results, null);
-    for (const { file, content } of files) {
+    for (const file of files) {
       try {
         info(`Processing test results from ${file}`);
+        const content = await import_fs3.default.promises.readFile(file, { encoding: "utf8" });
         const tr = await parser.parse(file, content);
         results.push(tr);
       } catch (error2) {

--- a/src/input-providers/input-provider.ts
+++ b/src/input-providers/input-provider.ts
@@ -1,15 +1,8 @@
 import Zip from 'adm-zip'
 
 export interface ReportInput {
-  trxZip: Zip
-  reports: {
-    [reportName: string]: FileContent[]
-  }
-}
-
-export interface FileContent {
-  file: string
-  content: string
+  files: string[]
+  createZip(): Zip
 }
 
 export interface InputProvider {

--- a/src/input-providers/local-file-provider.ts
+++ b/src/input-providers/local-file-provider.ts
@@ -1,6 +1,5 @@
-import * as fs from 'fs'
 import glob from 'fast-glob'
-import {FileContent, InputProvider, ReportInput} from './input-provider'
+import {InputProvider, ReportInput} from './input-provider'
 import Zip from 'adm-zip'
 import path from 'path'
 
@@ -11,22 +10,21 @@ export class LocalFileProvider implements InputProvider {
   ) {}
 
   async load(): Promise<ReportInput> {
-    const result: FileContent[] = []
-    const zip = new Zip()
+    const files: string[] = []
     for (const pat of this.pattern) {
       const paths = await glob(pat, {dot: true})
-      for (const file of paths) {
-        const dir = path.dirname(file)
-        zip.addLocalFile(file, dir)
-        const content = await fs.promises.readFile(file, {encoding: 'utf8'})
-        result.push({file, content})
-      }
+      files.push(...paths)
     }
 
     return {
-      trxZip: zip,
-      reports: {
-        [this.name]: result
+      files,
+      createZip: () => {
+        const zip = new Zip()
+        for (const file of files) {
+          const dir = path.dirname(file)
+          zip.addLocalFile(file, dir)
+        }
+        return zip
       }
     }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,6 @@ import * as github from '@actions/github'
 import {GitHub} from '@actions/github/lib/utils'
 
 import {LocalFileProvider} from './input-providers/local-file-provider'
-import {FileContent} from './input-providers/input-provider'
 import {ParseOptions} from './test-parser'
 import {TestRunResult, TestRunResultWithUrl} from './test-results'
 import {getAnnotations} from './report/get-annotations'
@@ -103,7 +102,8 @@ class TestReporter {
 
     if (this.resultsEndpoint?.length > 0) {
       try {
-        const readStream = input.trxZip.toBuffer()
+        const zip = input.createZip()
+        const readStream = zip.toBuffer()
         const version = fs.existsSync('./metadata/version.txt')
           ? fs.readFileSync('./metadata/version.txt').toString()
           : null
@@ -131,16 +131,14 @@ class TestReporter {
       }
     }
 
-    for (const [reportName, files] of Object.entries(input.reports)) {
-      try {
-        core.startGroup(`Creating test report ${reportName}`)
-        const tr = await this.createReport(parser, reportName, files)
-        if (tr != null) {
-          results.push(tr)
-        }
-      } finally {
-        core.endGroup()
+    try {
+      core.startGroup(`Creating test report ${this.name}`)
+      const tr = await this.createReport(parser, this.name, input.files)
+      if (tr != null) {
+        results.push(tr)
       }
+    } finally {
+      core.endGroup()
     }
 
     const isFailed = results.some(tr => tr.results.some(r => r.isFailed))
@@ -185,11 +183,7 @@ class TestReporter {
     }
   }
 
-  async createReport(
-    parser: DotnetTrxParser,
-    name: string,
-    files: FileContent[]
-  ): Promise<TestRunResultWithUrl | null> {
+  async createReport(parser: DotnetTrxParser, name: string, files: string[]): Promise<TestRunResultWithUrl | null> {
     if (files.length === 0) {
       core.warning(`No file matches path ${this.path}`)
     }
@@ -199,9 +193,10 @@ class TestReporter {
     let results: TestRunResult[] = []
     const result: TestRunResultWithUrl = new TestRunResultWithUrl(results, null)
 
-    for (const {file, content} of files) {
+    for (const file of files) {
       try {
         core.info(`Processing test results from ${file}`)
+        const content = await fs.promises.readFile(file, {encoding: 'utf8'})
         const tr = await parser.parse(file, content)
         results.push(tr)
       } catch (error) {


### PR DESCRIPTION
## Summary
- Fixed heap out of memory error when processing large test suites
- Previously all TRX file contents were loaded into memory at once
- Now files are read one at a time during processing
- Zip is created lazily only when uploading to results endpoint

## Root cause
For EVA's test suite with thousands of tests across many TRX files, loading all file contents upfront caused the Node.js heap to exceed 2GB and crash.

## Changes
- `input-provider.ts`: Changed interface to return file paths instead of contents
- `local-file-provider.ts`: Only collect file paths, create zip lazily via `createZip()`
- `main.ts`: Read file content just before processing each file

## Test plan
- [x] All tests pass locally
- [ ] Test on EVA's PostgreSQL test suite which was hitting OOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)