### PR TITLE
Add test-results-type, test-results-db-type inputs and pass PR contex…

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -78,6 +78,14 @@ inputs:
     description: Test results endpoint secret
     required: false
     default: ''
+  test-results-type:
+    description: Type of test run (integration, auditing, watchtower)
+    required: false
+    default: 'integration'
+  test-results-db-type:
+    description: Database type (mssql, yugabyte, postgres) — used for PR failure comments
+    required: false
+    default: ''
 outputs:
   conclusion:
     description: |

--- a/dist/index.js
+++ b/dist/index.js
@@ -49473,8 +49473,16 @@ var TestReporter = class {
         info(
           `Using EVA version ${version}, commit ${commitID}, branch ${this.context.branch}, current directory: ${(0, import_process.cwd)()}`
         );
-        const url = `${this.resultsEndpoint}TestResults?Secret=${this.resultsEndpointSecret}${version ? "&EVAVersion=" + version : ""}${commitID ? "&EVACommitID=" + commitID : ""}&EVABranch=${encodeURI(this.context.branch)}&Type=${encodeURI(this.resultsType)}${this.resultsDbType ? "&DbType=" + encodeURI(this.resultsDbType) : ""}`;
-        const headers = {};
+        const params = new URLSearchParams();
+        if (version) params.set("EVAVersion", version);
+        if (commitID) params.set("EVACommitID", commitID);
+        params.set("EVABranch", this.context.branch);
+        params.set("Type", this.resultsType);
+        if (this.resultsDbType) params.set("DbType", this.resultsDbType);
+        const url = `${this.resultsEndpoint}TestResults?${params.toString()}`;
+        const headers = {
+          Authorization: `Bearer ${this.resultsEndpointSecret}`
+        };
         const pr = context2.payload.pull_request;
         if (pr) {
           headers["X-GitHub-Token"] = this.token;

--- a/dist/index.js
+++ b/dist/index.js
@@ -49489,6 +49489,9 @@ var TestReporter = class {
           headers["X-PR-Number"] = pr.number.toString();
           headers["X-GitHub-Repo"] = `${context2.repo.owner}/${context2.repo.repo}`;
           headers["X-GitHub-Run-URL"] = `${context2.serverUrl}/${context2.repo.owner}/${context2.repo.repo}/actions/runs/${context2.runId}`;
+          info(`PR context: #${pr.number}, repo=${context2.repo.owner}/${context2.repo.repo}`);
+        } else {
+          info(`No PR context available (event: ${context2.eventName})`);
         }
         const response = await fetch(url, {
           method: "POST",

--- a/dist/index.js
+++ b/dist/index.js
@@ -49425,6 +49425,8 @@ var TestReporter = class {
     this.slackBranch = getInput("slack-branch", { required: false }) || "master";
     this.resultsEndpoint = getInput("test-results-endpoint", { required: false });
     this.resultsEndpointSecret = getInput("test-results-endpoint-secret", { required: false });
+    this.resultsType = getInput("test-results-type", { required: false }) || "integration";
+    this.resultsDbType = getInput("test-results-db-type", { required: false });
     this.context = getCheckRunContext();
     this.octokit = getOctokit(this.token);
     if (this.listSuites !== "all" && this.listSuites !== "failed") {
@@ -49471,10 +49473,19 @@ var TestReporter = class {
         info(
           `Using EVA version ${version}, commit ${commitID}, branch ${this.context.branch}, current directory: ${(0, import_process.cwd)()}`
         );
-        const url = `${this.resultsEndpoint}TestResults?Secret=${this.resultsEndpointSecret}${version ? "&EVAVersion=" + version : ""}${commitID ? "&EVACommitID=" + commitID : ""}&EVABranch=${encodeURI(this.context.branch)}`;
+        const url = `${this.resultsEndpoint}TestResults?Secret=${this.resultsEndpointSecret}${version ? "&EVAVersion=" + version : ""}${commitID ? "&EVACommitID=" + commitID : ""}&EVABranch=${encodeURI(this.context.branch)}&Type=${encodeURI(this.resultsType)}${this.resultsDbType ? "&DbType=" + encodeURI(this.resultsDbType) : ""}`;
+        const headers = {};
+        const pr = context2.payload.pull_request;
+        if (pr) {
+          headers["X-GitHub-Token"] = this.token;
+          headers["X-PR-Number"] = pr.number.toString();
+          headers["X-GitHub-Repo"] = `${context2.repo.owner}/${context2.repo.repo}`;
+          headers["X-GitHub-Run-URL"] = `${context2.serverUrl}/${context2.repo.owner}/${context2.repo.repo}/actions/runs/${context2.runId}`;
+        }
         const response = await fetch(url, {
           method: "POST",
-          body: new Uint8Array(readStream)
+          body: new Uint8Array(readStream),
+          headers
         });
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}: ${response.statusText}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -117,13 +117,17 @@ class TestReporter {
           `Using EVA version ${version}, commit ${commitID}, branch ${this.context.branch}, current directory: ${cwd()}`
         )
 
-        const url = `${this.resultsEndpoint}TestResults?Secret=${this.resultsEndpointSecret}${version ? '&EVAVersion=' + version : ''}${
-          commitID ? '&EVACommitID=' + commitID : ''
-        }&EVABranch=${encodeURI(this.context.branch)}&Type=${encodeURI(this.resultsType)}${
-          this.resultsDbType ? '&DbType=' + encodeURI(this.resultsDbType) : ''
-        }`
+        const params = new URLSearchParams()
+        if (version) params.set('EVAVersion', version)
+        if (commitID) params.set('EVACommitID', commitID)
+        params.set('EVABranch', this.context.branch)
+        params.set('Type', this.resultsType)
+        if (this.resultsDbType) params.set('DbType', this.resultsDbType)
+        const url = `${this.resultsEndpoint}TestResults?${params.toString()}`
 
-        const headers: Record<string, string> = {}
+        const headers: Record<string, string> = {
+          Authorization: `Bearer ${this.resultsEndpointSecret}`
+        }
         const pr = github.context.payload.pull_request
         if (pr) {
           headers['X-GitHub-Token'] = this.token

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,6 +45,8 @@ class TestReporter {
   readonly slackBranch = core.getInput('slack-branch', {required: false}) || 'master'
   readonly resultsEndpoint = core.getInput('test-results-endpoint', {required: false})
   readonly resultsEndpointSecret = core.getInput('test-results-endpoint-secret', {required: false})
+  readonly resultsType = core.getInput('test-results-type', {required: false}) || 'integration'
+  readonly resultsDbType = core.getInput('test-results-db-type', {required: false})
   readonly octokit: InstanceType<typeof GitHub>
   readonly context = getCheckRunContext()
 
@@ -117,10 +119,24 @@ class TestReporter {
 
         const url = `${this.resultsEndpoint}TestResults?Secret=${this.resultsEndpointSecret}${version ? '&EVAVersion=' + version : ''}${
           commitID ? '&EVACommitID=' + commitID : ''
-        }&EVABranch=${encodeURI(this.context.branch)}`
+        }&EVABranch=${encodeURI(this.context.branch)}&Type=${encodeURI(this.resultsType)}${
+          this.resultsDbType ? '&DbType=' + encodeURI(this.resultsDbType) : ''
+        }`
+
+        const headers: Record<string, string> = {}
+        const pr = github.context.payload.pull_request
+        if (pr) {
+          headers['X-GitHub-Token'] = this.token
+          headers['X-PR-Number'] = pr.number.toString()
+          headers['X-GitHub-Repo'] = `${github.context.repo.owner}/${github.context.repo.repo}`
+          headers['X-GitHub-Run-URL'] =
+            `${github.context.serverUrl}/${github.context.repo.owner}/${github.context.repo.repo}/actions/runs/${github.context.runId}`
+        }
+
         const response = await fetch(url, {
           method: 'POST',
-          body: new Uint8Array(readStream)
+          body: new Uint8Array(readStream),
+          headers
         })
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}: ${response.statusText}`)

--- a/src/main.ts
+++ b/src/main.ts
@@ -135,6 +135,9 @@ class TestReporter {
           headers['X-GitHub-Repo'] = `${github.context.repo.owner}/${github.context.repo.repo}`
           headers['X-GitHub-Run-URL'] =
             `${github.context.serverUrl}/${github.context.repo.owner}/${github.context.repo.repo}/actions/runs/${github.context.runId}`
+          core.info(`PR context: #${pr.number}, repo=${github.context.repo.owner}/${github.context.repo.repo}`)
+        } else {
+          core.info(`No PR context available (event: ${github.context.eventName})`)
         }
 
         const response = await fetch(url, {


### PR DESCRIPTION
…t headers

Pass Type and DbType query params to the TRX upload endpoint so auditing and watchtower runs are distinguished from integration runs. Forward PR context (token, number, repo, run URL) as headers so the server can post failure comments on PRs.